### PR TITLE
Added tower, ruins, monster randomisation

### DIFF
--- a/worlds/fe8/__init__.py
+++ b/worlds/fe8/__init__.py
@@ -191,10 +191,10 @@ class FE8World(World):
                 )
             )
 
-        for f in FILLER_ITEMS:
-            self.multiworld.itempool.append(
-                self.create_item_with_classification(f, ItemClassification.filler)
-            )
+        #for f in FILLER_ITEMS:
+        #    self.multiworld.itempool.append(
+        #        self.create_item_with_classification(f, ItemClassification.filler)
+        #    )
 
     def add_location_to_region(self, name: str, addr: Optional[int], region: Region):
         if addr is None:


### PR DESCRIPTION
## What is this fixing or adding?
Monster randomisation, start of tower and ruins randomisation.

## How was this tested?
By FEBuilder-skipping through the game. Multiworld testing was done by skipping to Tower 1 and playing that floor manually.

Known issues:
* Lyon can sometimes randomise into a monster, which causes a generation failure as there are no monster S ranks.
* There are more locations than items; excess items simply become nothing and cause generation issues when combined with other AP games (tested with SMZ3, which breaks, and ALTTP, which works).
* Monster enemies are tagged, but aren't properly handled at current. Some unstable enemies appear as a result.
