### PR TITLE
Speed up randomizer

### DIFF
--- a/worlds/fe8/constants.py
+++ b/worlds/fe8/constants.py
@@ -187,6 +187,11 @@ INTERNAL_RANDO_WEAPONS_ENTRY_SIZE = 0x20
 INTERNAL_RANDO_WEAPONS_NUM_ITEMS = 5
 INTERNAL_RANDO_WEAPONS_MAX_CLASSES = 22
 
+IS_PROMOTED = True
+NOT_PROMOTED = False
+
+
+
 # CR-soon cam: This is stretching the definition of a "constant" and should
 # probably go into a data file instead
 INTERNAL_RANDO_WEAPON_TABLE_ROWS = [

--- a/worlds/fe8/data/chapter_unit_blocks.json
+++ b/worlds/fe8/data/chapter_unit_blocks.json
@@ -11,7 +11,7 @@
             "name": "RenaisCastleGuards",
             "base": 9125144,
             "count": 8,
-            "logic": {"3": {"no_store": true}, "4": {"no_store": true}}
+            "logic": {"3": {"no_store": true}, "4": {"no_store": true}, "5": {"no_store": true}}
         },
         {
             "name": "RenaisMessenger",

--- a/worlds/fe8/data/jobdata.json
+++ b/worlds/fe8/data/jobdata.json
@@ -865,7 +865,8 @@
       "monster",
       "special",
       "generic",
-      "Claw"
+      "Claw",
+      "no_rando"
     ]
   },
   {
@@ -879,7 +880,8 @@
       "monster",
       "special",
       "generic",
-      "Claw"
+      "Claw",
+      "no_rando"
     ]
   },
   {
@@ -1101,7 +1103,8 @@
       "monster",
       "special",
       "flying",
-      "Breath"
+      "Breath",
+      "no_rando"
     ]
   },
   {

--- a/worlds/fe8/fe8py.py
+++ b/worlds/fe8/fe8py.py
@@ -312,11 +312,13 @@ class CharacterStore:
     ids_by_name: dict[str, list[int]]
     character_jobs: dict[str, JobData]
     character_tags: dict[str, set[str]]
+    character_inventory: dict[str, list[int]]
 
     def __init__(self, char_data: dict[str, dict[str, Any]]):
         self.names_by_id = {}
         self.character_tags = dict()
         self.ids_by_name = dict()
+        self.character_inventory = dict()
 
         for name, data in char_data.items():
             for i in data["ids"]:
@@ -339,6 +341,24 @@ class CharacterStore:
         if char_id not in self.names_by_id:
             return None
         return self.names_by_id[char_id]
+    
+    # these two could likely do the saftey checks faster / better but its still a improvement
+    def set_inventory(self, char_id: int, invin: bytes) -> list[int]:
+        if char_id not in self.names_by_id:
+            return None
+        name = self.names_by_id[char_id]
+        if name not in self.character_inventory:
+            self.character_inventory[name]= invin
+        return self.character_inventory[name]
+    
+    def get_inventory(self, char_id: int):
+        if char_id not in self.names_by_id:
+            return None
+        name = self.names_by_id[char_id]
+        if name not in self.character_inventory:
+            return None
+        else:
+            return self.character_inventory[name]
 
     def tags(self, char: Union[int, str]) -> Optional[set[str]]:
         if isinstance(char, int):
@@ -654,9 +674,16 @@ class FE8Randomizer:
         inventory = unit[INVENTORY_INDEX : INVENTORY_INDEX + INVENTORY_SIZE]
 
 
-
+       
         if char in self.character_store:
             new_job = self.character_store[char]
+            # sets invintory from a earlier copy of yourself, if a invintory is stored
+            # as cutscene units usually have 0 items 
+            # not saving new items as l'rachel and other route splits have different invintorys
+            # so this keeps that functionallity 
+            new_inventory = self.character_store.get_inventory(char)
+            if new_inventory is None:
+                new_inventory = self.select_new_inventory(new_job, inventory, logic)
         else:
             # Checks to see if monsters are in logic or if it should just use humans
             if "player" in logic and logic["player"] and not self.config["player_monster"]:
@@ -677,11 +704,16 @@ class FE8Randomizer:
                 job_pool=self.jobs_pools[job.is_promoted][Race][Rules],
                 job_valid=lambda job: self.job_valid(job, char, logic),
             )
-
+            new_inventory = self.select_new_inventory(new_job, inventory, logic)
             if not no_store:
+                # likely could combine these 2 functions but might be read / stored in other places
+                # only storing if you have 2 itmes as most units that appear in cutscenes have 0 BUT l'rachel and co have 1
+                # so only saves units that have 2 or more items
                 self.character_store[char] = new_job
+                if inventory[1] !=0:
+                    self.character_store.set_inventory(char, new_inventory)
 
-        new_inventory = self.select_new_inventory(new_job, inventory, logic)
+        
 
         self.rom[data_offset + 1] = new_job.id
         for i, item_id in enumerate(new_inventory):

--- a/worlds/fe8/fe8py.py
+++ b/worlds/fe8/fe8py.py
@@ -498,9 +498,9 @@ class FE8Randomizer:
         for kind in WeaponKind:
             self.weapons_by_kind_rank[kind] = defaultdict(list)
 
-        # Weapons are given their own 2d dictionary so instead of just trying every weapon at a weapon level
-        # we instead only see if they can use weapons equipable at that weapon level
-        # just need to get what weapons they can equip first
+        # Weapons are given their own 2d dictionary so we can get a small weapon pool
+        # Just find out what weapon levels the job has then what weapon rank you looking for
+
         for weap in self.weapons_by_id.values():
             self.weapons_by_kind_rank[weap.kind][weap.rank].append(weap)
 
@@ -577,7 +577,7 @@ class FE8Randomizer:
             return item_id
         weapon_attrs = self.weapons_by_id[item_id]
 
-        # gets the weapon types equip able at and adds them to the pool for the current weapon being changed
+        # gets the weapon types equipable and adds them to the pool for the current weapon being changed
         useable = []
         for weapon_levels in job.usable_weapons:
             useable += self.weapons_by_kind_rank[weapon_levels][weapon_attrs.rank]
@@ -592,7 +592,7 @@ class FE8Randomizer:
             logging.warning(f"  rank: {weapon_attrs.rank}")
             logging.warning(f"  logic: {json.dumps(logic, indent=2)}")
 
-            # gets the first type of equip able weapon
+            # gets the first type of equipable weapon
             first_type = next(iter(job.usable_weapons))
             choices = [
                 weap
@@ -690,10 +690,11 @@ class FE8Randomizer:
 
         if char in self.character_store:
             new_job = self.character_store[char]
-            # sets invintory from a earlier copy of yourself, if a invintory is stored
-            # as cutscene units usually have 0 items
-            # not saving new items as l'rachel and other route splits have different invintorys
-            # so this keeps that functionallity
+            # sets inventory from an earlier copy of yourself, if an inventory is stored
+            # as cutscene units usually have 0 items not all are stored
+            # not saving new items if you appeared in a cutscene 
+            # as L'Arachel and other route splits have different inventories
+            # so this keeps that functionality as well
             new_inventory = self.character_store.get_inventory(char)
             if new_inventory is None:
                 new_inventory = self.select_new_inventory(new_job, inventory, logic)
@@ -707,10 +708,10 @@ class FE8Randomizer:
                 Race = JobRace.HUMAN
             else:
                 Race = JobRace.ALL
-            # Checks to see if we should use the respective flier pool of classes
-            # Add other checks here for other pools added in later :) as a else if
-            # could make pool intersections if you want to do like ranged fliers.... but shouldn't need that ever
-            # as only morgall and its promotion fit that definition
+            # Checks to see what job pool to use
+            # Add other checks here for other pools added in later as a else if
+            # could make pool intersections if you want to do like ranged fliers
+            # but should never need to
             if "must_fly" in logic and logic["must_fly"]:
                 Rules = JobType.FLIER
             else:
@@ -724,8 +725,9 @@ class FE8Randomizer:
             new_inventory = self.select_new_inventory(new_job, inventory, logic)
             if not no_store:
                 # likely could combine these 2 functions but might be read / stored in other places
-                # only storing if you have 2 itmes as most units that appear in cutscenes have 0 BUT l'rachel and co have 1
+                # only storing if you have 2 items as most units that appear in cutscenes have 0 BUT L'Arachel and co have 1
                 # so only saves units that have 2 or more items
+
                 self.character_store[char] = new_job
                 if inventory[1] != 0:
                     self.character_store.set_inventory(char, new_inventory)

--- a/worlds/fe8/fe8py.py
+++ b/worlds/fe8/fe8py.py
@@ -71,6 +71,8 @@ from .constants import (
     FEMALE_JOBS,
     SONG_TABLE_BASE,
     SONG_SIZE,
+    IS_PROMOTED,
+    NOT_PROMOTED
 )
 
 DEBUG = False
@@ -244,6 +246,17 @@ class WeaponRank(IntEnum):
             case "S":
                 return WeaponRank.S
         raise ValueError
+    
+class JobRace(IntEnum):
+    ALL = 0
+    HUMAN = 1
+    MONSTER = 2
+
+class JobType(IntEnum):
+    ANY = 0
+    RANGED = 1
+    FLIER = 2
+    LOCKPICK = 3
 
 
 @dataclass
@@ -387,10 +400,8 @@ class FE8Randomizer:
     character_store: CharacterStore
     jobs_by_id: dict[int, JobData]
     valid_distribs_by_row: dict[int, list[int]]
-    promoted_jobs: list[JobData]
-    unpromoted_jobs: list[JobData]
+    jobs_pools:dict[bool,dict[JobRace, dict[JobType, list[JobData]]]]
     songs: dict[str, dict[int, str]]
-
     random: Random
     rom: bytearray
     config: dict[str, Any]
@@ -427,19 +438,43 @@ class FE8Randomizer:
         self.weapons_by_name = {item.name: item for item in item_data}
         self.jobs_by_id = {job.id: job for job in job_data}
 
-        self.promoted_jobs = [
-            job for job in job_data if job.is_promoted and "no_rando" not in job.tags
-        ]
-        self.unpromoted_jobs = [
-            job
-            for job in job_data
-            if not job.is_promoted and "no_rando" not in job.tags
-        ]
+
+        self.jobs_pools = defaultdict(list)
+        for promo in [IS_PROMOTED,NOT_PROMOTED]:
+            self.jobs_pools[promo] = defaultdict(list)
+            for race in JobRace:
+                self.jobs_pools[promo][race] = defaultdict(list)
+
+        # sorting classes into the following class pools
+        # 1. if they are promoted or not
+        # 2. then, if they are a "human" or a "monster" class, as well as a "all" grouping
+        # 3. then by tags, so is the class flying, lockpick or ranged atm but more can be added in time
+        # This means there is a dedicated pool for promoted human fliers to make randomization faster
+        for job in job_data:
+            if "no_rando" not in job.tags:
+                if "monster" in job.tags:
+                    Race = JobRace.MONSTER
+                else:
+                    Race = JobRace.HUMAN
+                if "flying" in job.tags:
+                    self.jobs_pools[job.is_promoted][Race][JobType.FLIER].append(job)
+                    self.jobs_pools[job.is_promoted][JobRace.ALL][JobType.FLIER].append(job)
+                elif "Lockpick" in job.tags:
+                    self.jobs_pools[job.is_promoted][Race][JobType.LOCKPICK].append(job)
+                    self.jobs_pools[job.is_promoted][JobRace.ALL][JobType.LOCKPICK].append(job)
+                if "ranged" in job.tags:
+                    self.jobs_pools[job.is_promoted][Race][JobType.RANGED].append(job)
+                    self.jobs_pools[job.is_promoted][JobRace.ALL][JobType.RANGED].append(job)
+                self.jobs_pools[job.is_promoted][JobRace.ALL][JobType.ANY].append(job)
+
 
         self.weapons_by_kind_rank = defaultdict(list)
         for kind in WeaponKind:
             self.weapons_by_kind_rank[kind] = defaultdict(list)
 
+        # Weapons are given their own 2d dictionary so instead of just trying every weapon at a weapon level
+        # we instead only see if they can use weapons equipable at that weapon level
+        # just need to get what weapons they can equip first
         for weap in self.weapons_by_id.values():
             self.weapons_by_kind_rank[weap.kind][weap.rank].append(weap)
 
@@ -476,22 +511,12 @@ class FE8Randomizer:
         # the "no_" prefix adds the tag to the invalid tag list
         # "no_flying" makes any job with "flying" tag invalid
         notags = set()
-        # config option for disabling player unit monsters
-        if "player" in logic and logic["player"] and not self.config["player_monster"]:
-            notags.add("monster")
+
         for x in logic:
             if x.startswith("no_") and logic[x]:
                 notags.add(x.removeprefix("no_"))
         # job is invalid if it has any of the tags in notags
         if notags and notags & job.tags:
-            return False
-
-        # CR-soon cam: see above
-        if job.name in ("Dracozombie", "Revenant", "Entombed"):
-            return False
-
-        if "must_fly" in logic and logic["must_fly"] and "flying" not in job.tags:
-            # demand that valid job has the "flying" tag
             return False
 
         if "must_fight" in logic and logic["must_fight"]:
@@ -513,10 +538,11 @@ class FE8Randomizer:
             return item_id
         weapon_attrs = self.weapons_by_id[item_id]
 
+        # gets the weapon types equip able at and adds them to the pool for the current weapon being changed 
         useable=[]
         for weapon_levels in job.usable_weapons: 
             useable += self.weapons_by_kind_rank[weapon_levels][weapon_attrs.rank]
-
+        
         choices = [
             weap
             for weap in useable
@@ -531,6 +557,7 @@ class FE8Randomizer:
             logging.warning(f"  rank: {weapon_attrs.rank}")
             logging.warning(f"  logic: {json.dumps(logic, indent=2)}")
 
+            #gets the first type of equip able weapon
             first_type = next(iter(job.usable_weapons))
             choices = [
                 weap
@@ -576,12 +603,10 @@ class FE8Randomizer:
     def select_new_job(
         self,
         job: JobData,
-        unpromoted_pool: Iterable[JobData],
-        promoted_pool: Iterable[JobData],
+        job_pool: Iterable[JobData],
         job_valid: Callable[[JobData], bool],
     ) -> JobData:
-        new_job_pool = promoted_pool if job.is_promoted else unpromoted_pool
-        choices = [job for job in new_job_pool if job_valid(job)]
+        choices = [job for job in job_pool if job_valid(job)]
         if not choices:
             logging.warning("LOGIC ERROR: no valid jobs")
             logging.warning(f"  original job: {job.name}")
@@ -628,13 +653,28 @@ class FE8Randomizer:
         autolevel = unit[3] & 1
         inventory = unit[INVENTORY_INDEX : INVENTORY_INDEX + INVENTORY_SIZE]
 
+
+
         if char in self.character_store:
             new_job = self.character_store[char]
         else:
+            # Checks to see if monsters are in logic or if it should just use humans
+            if "player" in logic and logic["player"] and not self.config["player_monster"]:
+                Race = JobRace.HUMAN
+            else:
+                Race = JobRace.ALL
+            # Checks to see if we should use the respective flier pool of classes
+            # Add other checks here for other pools added in later :) as a else if
+            # could make pool intersections if you want to do like ranged fliers.... but shouldn't need that ever
+            # as only morgall and its promotion fit that definition 
+            if "must_fly" in logic and logic["must_fly"]:
+                Rules = JobType.FLIER
+            else:
+                Rules = JobType.ANY
+            
             new_job = self.select_new_job(
                 job,
-                unpromoted_pool=self.unpromoted_jobs,
-                promoted_pool=self.promoted_jobs,
+                job_pool=self.jobs_pools[job.is_promoted][Race][Rules],
                 job_valid=lambda job: self.job_valid(job, char, logic),
             )
 
@@ -781,12 +821,11 @@ class FE8Randomizer:
                     jobset.pools()
                     # We _could_ repoint this and not need to check, but eh
                     if len(jobset) >= INTERNAL_RANDO_WEAPONS_MAX_CLASSES
-                    else (self.unpromoted_jobs, self.promoted_jobs)
+                    else (self.jobs_pools[NOT_PROMOTED][JobRace.ALL][JobType.ANY], self.jobs_pools[IS_PROMOTED][JobRace.ALL][JobType.ANY])
                 )
                 new_job = self.select_new_job(
                     job,
-                    unpromoted_pool=unpromoted_pool,
-                    promoted_pool=promoted_pool,
+                    promoted_pool if job.is_promoted else unpromoted_pool,
                     job_valid=job_valid_for_internal_rando,
                 )
                 self.rom[offs + j] = new_job.id

--- a/worlds/fe8/fe8py.py
+++ b/worlds/fe8/fe8py.py
@@ -363,9 +363,6 @@ class CharacterStore:
 # CR cam: Eirika and Ephraim should be able to use their respective weapons if
 # they get randomized into the right class.
 def weapon_usable(weapon: WeaponData, job: JobData, logic: dict[str, Any]) -> bool:
-    if weapon.kind not in job.usable_weapons:
-        return False
-
     if any(lock not in job.tags for lock in weapon.locks):
         return False
 
@@ -385,8 +382,8 @@ def weapon_usable(weapon: WeaponData, job: JobData, logic: dict[str, Any]) -> bo
 class FE8Randomizer:
     unit_blocks: dict[str, list[UnitBlock]]
     weapons_by_id: dict[int, WeaponData]
+    weapons_by_kind_rank: dict[WeaponKind, dict[WeaponRank, list[WeaponData]]]
     weapons_by_name: dict[str, WeaponData]
-    weapons_by_rank: dict[WeaponRank, list[WeaponData]]
     character_store: CharacterStore
     jobs_by_id: dict[int, JobData]
     valid_distribs_by_row: dict[int, list[int]]
@@ -439,24 +436,27 @@ class FE8Randomizer:
             if not job.is_promoted and "no_rando" not in job.tags
         ]
 
-        self.weapons_by_rank = defaultdict(list)
+        self.weapons_by_kind_rank = defaultdict(list)
+        for kind in WeaponKind:
+            self.weapons_by_kind_rank[kind] = defaultdict(list)
 
         for weap in self.weapons_by_id.values():
-            self.weapons_by_rank[weap.rank].append(weap)
+            self.weapons_by_kind_rank[weap.kind][weap.rank].append(weap)
 
         # Dark has no E-ranked weapons by default.
-        self.weapons_by_rank[WeaponRank.E].append(self.weapons_by_name["Flux"])
+        self.weapons_by_kind_rank[WeaponKind.DARK][WeaponRank.E].append(self.weapons_by_name["Flux"])
 
         # cam: Should we allow Lyon to become a monster?
 
-        self.weapons_by_rank[WeaponRank.D].append(self.weapons_by_name["Fiery Fang"])
-        self.weapons_by_rank[WeaponRank.C].append(self.weapons_by_name["Fiery Fang"])
-        self.weapons_by_rank[WeaponRank.A].append(self.weapons_by_name["Hellfang"])
-        self.weapons_by_rank[WeaponRank.S].append(self.weapons_by_name["Hellfang"])
 
-        self.weapons_by_rank[WeaponRank.A].append(self.weapons_by_name["Fetid Claw"])
-        self.weapons_by_rank[WeaponRank.S].append(self.weapons_by_name["Fetid Claw"])
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.D].append(self.weapons_by_name["Fiery Fang"])
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.C].append(self.weapons_by_name["Fiery Fang"])
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.A].append(self.weapons_by_name["Hellfang"])
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.S].append(self.weapons_by_name["Hellfang"])
 
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.A].append(self.weapons_by_name["Fetid Claw"])
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.S].append(self.weapons_by_name["Fetid Claw"])
+ 
         # CR-soon cam:
         # Darr: Dragon zombies experience the same problem. I've disabled them for now;
         # they only have one weapon and E-rank Wretched Air does not sound fun.
@@ -513,12 +513,16 @@ class FE8Randomizer:
             return item_id
         weapon_attrs = self.weapons_by_id[item_id]
 
+        useable=[]
+        for weapon_levels in job.usable_weapons: 
+            useable += self.weapons_by_kind_rank[weapon_levels][weapon_attrs.rank]
+
         choices = [
             weap
-            for weap in self.weapons_by_rank[weapon_attrs.rank]
+            for weap in useable
             if weapon_usable(weap, job, logic)
         ]
-
+ 
         if not choices:
             import json
 
@@ -527,9 +531,10 @@ class FE8Randomizer:
             logging.warning(f"  rank: {weapon_attrs.rank}")
             logging.warning(f"  logic: {json.dumps(logic, indent=2)}")
 
+            first_type = next(iter(job.usable_weapons))
             choices = [
                 weap
-                for weap in self.weapons_by_rank[WeaponRank.E]
+                for weap in self.weapons_by_kind_rank[WeaponRank.E][first_type]
                 if weapon_usable(weap, job, dict())
             ]
 

--- a/worlds/fe8/fe8py.py
+++ b/worlds/fe8/fe8py.py
@@ -72,7 +72,7 @@ from .constants import (
     SONG_TABLE_BASE,
     SONG_SIZE,
     IS_PROMOTED,
-    NOT_PROMOTED
+    NOT_PROMOTED,
 )
 
 DEBUG = False
@@ -246,11 +246,13 @@ class WeaponRank(IntEnum):
             case "S":
                 return WeaponRank.S
         raise ValueError
-    
+
+
 class JobRace(IntEnum):
     ALL = 0
     HUMAN = 1
     MONSTER = 2
+
 
 class JobType(IntEnum):
     ANY = 0
@@ -341,16 +343,16 @@ class CharacterStore:
         if char_id not in self.names_by_id:
             return None
         return self.names_by_id[char_id]
-    
+
     # these two could likely do the saftey checks faster / better but its still a improvement
     def set_inventory(self, char_id: int, invin: bytes) -> list[int]:
         if char_id not in self.names_by_id:
             return None
         name = self.names_by_id[char_id]
         if name not in self.character_inventory:
-            self.character_inventory[name]= invin
+            self.character_inventory[name] = invin
         return self.character_inventory[name]
-    
+
     def get_inventory(self, char_id: int):
         if char_id not in self.names_by_id:
             return None
@@ -420,7 +422,7 @@ class FE8Randomizer:
     character_store: CharacterStore
     jobs_by_id: dict[int, JobData]
     valid_distribs_by_row: dict[int, list[int]]
-    jobs_pools:dict[bool,dict[JobRace, dict[JobType, list[JobData]]]]
+    jobs_pools: dict[bool, dict[JobRace, dict[JobType, list[JobData]]]]
     songs: dict[str, dict[int, str]]
     random: Random
     rom: bytearray
@@ -458,9 +460,8 @@ class FE8Randomizer:
         self.weapons_by_name = {item.name: item for item in item_data}
         self.jobs_by_id = {job.id: job for job in job_data}
 
-
         self.jobs_pools = defaultdict(list)
-        for promo in [IS_PROMOTED,NOT_PROMOTED]:
+        for promo in [IS_PROMOTED, NOT_PROMOTED]:
             self.jobs_pools[promo] = defaultdict(list)
             for race in JobRace:
                 self.jobs_pools[promo][race] = defaultdict(list)
@@ -478,15 +479,20 @@ class FE8Randomizer:
                     Race = JobRace.HUMAN
                 if "flying" in job.tags:
                     self.jobs_pools[job.is_promoted][Race][JobType.FLIER].append(job)
-                    self.jobs_pools[job.is_promoted][JobRace.ALL][JobType.FLIER].append(job)
+                    self.jobs_pools[job.is_promoted][JobRace.ALL][JobType.FLIER].append(
+                        job
+                    )
                 elif "Lockpick" in job.tags:
                     self.jobs_pools[job.is_promoted][Race][JobType.LOCKPICK].append(job)
-                    self.jobs_pools[job.is_promoted][JobRace.ALL][JobType.LOCKPICK].append(job)
+                    self.jobs_pools[job.is_promoted][JobRace.ALL][
+                        JobType.LOCKPICK
+                    ].append(job)
                 if "ranged" in job.tags:
                     self.jobs_pools[job.is_promoted][Race][JobType.RANGED].append(job)
-                    self.jobs_pools[job.is_promoted][JobRace.ALL][JobType.RANGED].append(job)
+                    self.jobs_pools[job.is_promoted][JobRace.ALL][
+                        JobType.RANGED
+                    ].append(job)
                 self.jobs_pools[job.is_promoted][JobRace.ALL][JobType.ANY].append(job)
-
 
         self.weapons_by_kind_rank = defaultdict(list)
         for kind in WeaponKind:
@@ -499,19 +505,32 @@ class FE8Randomizer:
             self.weapons_by_kind_rank[weap.kind][weap.rank].append(weap)
 
         # Dark has no E-ranked weapons by default.
-        self.weapons_by_kind_rank[WeaponKind.DARK][WeaponRank.E].append(self.weapons_by_name["Flux"])
+        self.weapons_by_kind_rank[WeaponKind.DARK][WeaponRank.E].append(
+            self.weapons_by_name["Flux"]
+        )
 
         # cam: Should we allow Lyon to become a monster?
 
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.D].append(
+            self.weapons_by_name["Fiery Fang"]
+        )
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.C].append(
+            self.weapons_by_name["Fiery Fang"]
+        )
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.A].append(
+            self.weapons_by_name["Hellfang"]
+        )
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.S].append(
+            self.weapons_by_name["Hellfang"]
+        )
 
-        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.D].append(self.weapons_by_name["Fiery Fang"])
-        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.C].append(self.weapons_by_name["Fiery Fang"])
-        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.A].append(self.weapons_by_name["Hellfang"])
-        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.S].append(self.weapons_by_name["Hellfang"])
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.A].append(
+            self.weapons_by_name["Fetid Claw"]
+        )
+        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.S].append(
+            self.weapons_by_name["Fetid Claw"]
+        )
 
-        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.A].append(self.weapons_by_name["Fetid Claw"])
-        self.weapons_by_kind_rank[WeaponKind.MONSTER_WEAPON][WeaponRank.S].append(self.weapons_by_name["Fetid Claw"])
- 
         # CR-soon cam:
         # Darr: Dragon zombies experience the same problem. I've disabled them for now;
         # they only have one weapon and E-rank Wretched Air does not sound fun.
@@ -558,17 +577,13 @@ class FE8Randomizer:
             return item_id
         weapon_attrs = self.weapons_by_id[item_id]
 
-        # gets the weapon types equip able at and adds them to the pool for the current weapon being changed 
-        useable=[]
-        for weapon_levels in job.usable_weapons: 
+        # gets the weapon types equip able at and adds them to the pool for the current weapon being changed
+        useable = []
+        for weapon_levels in job.usable_weapons:
             useable += self.weapons_by_kind_rank[weapon_levels][weapon_attrs.rank]
-        
-        choices = [
-            weap
-            for weap in useable
-            if weapon_usable(weap, job, logic)
-        ]
- 
+
+        choices = [weap for weap in useable if weapon_usable(weap, job, logic)]
+
         if not choices:
             import json
 
@@ -577,7 +592,7 @@ class FE8Randomizer:
             logging.warning(f"  rank: {weapon_attrs.rank}")
             logging.warning(f"  logic: {json.dumps(logic, indent=2)}")
 
-            #gets the first type of equip able weapon
+            # gets the first type of equip able weapon
             first_type = next(iter(job.usable_weapons))
             choices = [
                 weap
@@ -673,32 +688,34 @@ class FE8Randomizer:
         autolevel = unit[3] & 1
         inventory = unit[INVENTORY_INDEX : INVENTORY_INDEX + INVENTORY_SIZE]
 
-
-       
         if char in self.character_store:
             new_job = self.character_store[char]
             # sets invintory from a earlier copy of yourself, if a invintory is stored
-            # as cutscene units usually have 0 items 
+            # as cutscene units usually have 0 items
             # not saving new items as l'rachel and other route splits have different invintorys
-            # so this keeps that functionallity 
+            # so this keeps that functionallity
             new_inventory = self.character_store.get_inventory(char)
             if new_inventory is None:
                 new_inventory = self.select_new_inventory(new_job, inventory, logic)
         else:
             # Checks to see if monsters are in logic or if it should just use humans
-            if "player" in logic and logic["player"] and not self.config["player_monster"]:
+            if (
+                "player" in logic
+                and logic["player"]
+                and not self.config["player_monster"]
+            ):
                 Race = JobRace.HUMAN
             else:
                 Race = JobRace.ALL
             # Checks to see if we should use the respective flier pool of classes
             # Add other checks here for other pools added in later :) as a else if
             # could make pool intersections if you want to do like ranged fliers.... but shouldn't need that ever
-            # as only morgall and its promotion fit that definition 
+            # as only morgall and its promotion fit that definition
             if "must_fly" in logic and logic["must_fly"]:
                 Rules = JobType.FLIER
             else:
                 Rules = JobType.ANY
-            
+
             new_job = self.select_new_job(
                 job,
                 job_pool=self.jobs_pools[job.is_promoted][Race][Rules],
@@ -710,10 +727,8 @@ class FE8Randomizer:
                 # only storing if you have 2 itmes as most units that appear in cutscenes have 0 BUT l'rachel and co have 1
                 # so only saves units that have 2 or more items
                 self.character_store[char] = new_job
-                if inventory[1] !=0:
+                if inventory[1] != 0:
                     self.character_store.set_inventory(char, new_inventory)
-
-        
 
         self.rom[data_offset + 1] = new_job.id
         for i, item_id in enumerate(new_inventory):
@@ -853,7 +868,10 @@ class FE8Randomizer:
                     jobset.pools()
                     # We _could_ repoint this and not need to check, but eh
                     if len(jobset) >= INTERNAL_RANDO_WEAPONS_MAX_CLASSES
-                    else (self.jobs_pools[NOT_PROMOTED][JobRace.ALL][JobType.ANY], self.jobs_pools[IS_PROMOTED][JobRace.ALL][JobType.ANY])
+                    else (
+                        self.jobs_pools[NOT_PROMOTED][JobRace.ALL][JobType.ANY],
+                        self.jobs_pools[IS_PROMOTED][JobRace.ALL][JobType.ANY],
+                    )
                 )
                 new_job = self.select_new_job(
                     job,
@@ -1082,11 +1100,11 @@ class FE8Randomizer:
         cuts = sorted(self.random.sample(range(1, total), STATS_COUNT))
         result = []
         overflow = 0
-        for st, end in zip([0]+cuts, cuts+[total]):
-            growth = end-st
+        for st, end in zip([0] + cuts, cuts + [total]):
+            growth = end - st
             if growth > 255:
                 result.append(255)
-                overflow += growth-255
+                overflow += growth - 255
             else:
                 result.append(growth)
         while overflow > 0:
@@ -1097,7 +1115,7 @@ class FE8Randomizer:
             result[i] += overflow
             overflow = 0
             if result[i] > 255:
-                overflow = result[i]-255
+                overflow = result[i] - 255
                 result[i] = 255
         return result
 

--- a/worlds/fe8/rom.py
+++ b/worlds/fe8/rom.py
@@ -4,6 +4,7 @@
 # randomization, stat tweaks, etc).
 
 import json
+import time
 from random import Random
 from typing import TYPE_CHECKING
 
@@ -46,6 +47,7 @@ class FE8PatchExtension(APPatchExtension):
 
     @staticmethod
     def apply_gameplay_changes(caller: APProcedurePatch, rom: bytes) -> bytes:
+        t0 = time.time()
         config = json.loads(caller.get_file("config.json").decode("UTF-8"))
         random = Random(config["seed"] + config["player"])
         mut_rom = bytearray(rom)
@@ -66,7 +68,10 @@ class FE8PatchExtension(APPatchExtension):
 
         randomizer.randomize_growths(*config["growth_rando"])
         randomizer.randomize_music(config["music_rando"])
-
+        t1 = time.time()
+        
+        with open('time.csv','a') as fd:
+            fd.write('\n'+str(t1-t0))
         return bytes(mut_rom)
 
 

--- a/worlds/fe8/rom.py
+++ b/worlds/fe8/rom.py
@@ -2,9 +2,7 @@
 # primarily concerned with interfacing the FE8 world with Archipelago, whereas
 # `fe8py` makes semantic changes to the game itself (meaning the core
 # randomization, stat tweaks, etc).
-
 import json
-import time
 from random import Random
 from typing import TYPE_CHECKING
 
@@ -47,7 +45,6 @@ class FE8PatchExtension(APPatchExtension):
 
     @staticmethod
     def apply_gameplay_changes(caller: APProcedurePatch, rom: bytes) -> bytes:
-        t0 = time.time()
         config = json.loads(caller.get_file("config.json").decode("UTF-8"))
         random = Random(config["seed"] + config["player"])
         mut_rom = bytearray(rom)
@@ -68,10 +65,6 @@ class FE8PatchExtension(APPatchExtension):
 
         randomizer.randomize_growths(*config["growth_rando"])
         randomizer.randomize_music(config["music_rando"])
-        t1 = time.time()
-        
-        with open('time.csv','a') as fd:
-            fd.write('\n'+str(t1-t0))
         return bytes(mut_rom)
 
 


### PR DESCRIPTION
The main idea under both these changes, was giving a better pool system for the choices to be made.

1. Weapons

It used to get just the weapon level of the old unit in SS then try and give the new unit every weapon of the same rank to see if they could use it or if it was illegal (rapier is illegal if not Eirika)

Now it checks what weapons the new class can hold and build a weapon pool of only those weapons at the weapon level of the original SS unit, or if it is illegal

2. Classes

Old system was two pools of classes promoted and not promoted, would then check logic or if it was a legal job.

New system gives a tree like hierarchy of jobs of:
is it promoted
is it human or monster or all
is it all, or flier, thief... etc

This means there are pools for promoted human fliers
or pool for un-promoted, all races, all classes

Added the no_rando tag to 3 jobs that were guaranteed to be rejected (Dracozombie", "Revenant", "Entombed) so that they never enter the pools


It was tested by using a test seed and seeing if results were legal in FEbuilder

I also timed how long it took before and after all the changes and found it to be about 25% faster from 0.22 sec to 0.16 on my PC
this was done by using import time and taking two moments... ran that 10 times all on same patch file